### PR TITLE
maxDelay skipped when options.node is type String

### DIFF
--- a/src/jmuxer.js
+++ b/src/jmuxer.js
@@ -325,11 +325,11 @@ export default class JMuxer extends Event {
     }
 
     cancelDelay() {
-        if (this.options.node.buffered && this.options.node.buffered.length > 0 && !this.options.node.seeking) {
-            const end = this.options.node.buffered.end(0);
-            if (end - this.options.node.currentTime > (this.options.maxDelay / 1000)) {
-                console.log('delay', this.delay++);
-                this.options.node.currentTime = end - 0.001;
+        if (this.node.buffered && this.node.buffered.length > 0 && !this.node.seeking) {
+            const end = this.node.buffered.end(0);
+            if (end - this.node.currentTime > (this.options.maxDelay / 1000)) {
+                console.log('delay');
+                this.node.currentTime = end - 0.001;
             }
         }
     }


### PR DESCRIPTION
Fix a bug where maxDelay was not honored when node was specified using a string instead of a video element.
this.options.node.buffered is undefined causing the delay code not to be run. 
This can be easily worked around by using a video node instead of a String in the constructor

Additionally, remove this.delay++ as this.delay is undefined

Also, I just wanted to say sincerely - Thank you so much for making this project and giving it away. It's just absolutely perfect, I've spent the last several weeks trying to get live streaming to work and within a day of finding this library everything is solved. It does *exactly* what I was looking for *so* cleanly, it's honestly beautiful. <3